### PR TITLE
fix: Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: "Slides for OpenTofu Tracing talk, originally given at DevOps Days Montreal, 2024"
   annotations:
     github.com/project-slug: liatrio/opentofu-tracing-talk
-    backstage.io/techdocs-ref: dir:.
   tags:
     - slidev
     - slides


### PR DESCRIPTION
Removing techdocs annotation so it isn't loaded on the docs page anymore